### PR TITLE
chore: add a scope to the package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dotenv-apart",
+  "name": "@ikngtty/dotenv-apart",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dotenv-apart",
+      "name": "@ikngtty/dotenv-apart",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dotenv-apart",
+  "name": "@ikngtty/dotenv-apart",
   "description": "A global executable to run applications with the ENV variables in a dotenv file out of the project directory.",
   "version": "0.0.0",
   "author": "ikngtty",


### PR DESCRIPTION
`dotenv-apart` -> `@ikngtty/dotenv-apart`
This tool is not published in the npm registry, so there is a possibility that the package name conflicts with an other tool. This commit aims to reduce the possiblity.